### PR TITLE
Added missing NuttX header.

### DIFF
--- a/components/wpa_supplicant/src/rsn_supp/wpa.c
+++ b/components/wpa_supplicant/src/rsn_supp/wpa.c
@@ -32,6 +32,8 @@
 #include "crypto/sha256.h"
 #ifndef __NuttX__
 #include "esp_rom_sys.h"
+#else
+#include <nuttx/arch.h>
 #endif
 #include "common/bss.h"
 #include "esp_common_i.h"


### PR DESCRIPTION
## Description

We are working to eliminate the inclusion of `nuttx/arch.h` within `userspace.h` for the NuttX kernel. To facilitate this change, we must incorporate the missing NuttX header files into third-party code. Notably, `wpa.c` is using the `up_udelay` function without including the `nuttx/arch.h` header.

## Related

Resolved CI errors in https://github.com/apache/nuttx/pull/14351.

## Testing

Tested.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ Y ] 🚨 This PR does not introduce breaking changes.
- [ Y ] All CI checks (GH Actions) pass.
- [ Y ] Documentation is updated as needed.
- [ Y ] Tests are updated or added as necessary.
- [ Y ] Code is well-commented, especially in complex areas.
- [ Y ] Git history is clean — commits are squashed to the minimum necessary.

@tmedicci  Really sorry for my previous stupid mistake. Please check it. Thanks.