### PR TITLE
esp32: replace spin_lock_irqsave with raw_spin_lock_irqsave.

### DIFF
--- a/components/esp_hw_support/esp_clk.c
+++ b/components/esp_hw_support/esp_clk.c
@@ -50,10 +50,10 @@
 #ifdef __NuttX__
 #define ENTER_CRITICAL_SECTION(lock) do { \
             assert(g_flags == UINT32_MAX); \
-            g_flags = spin_lock_irqsave(lock); \
+            g_flags = raw_spin_lock_irqsave(lock); \
         } while(0)
 #define LEAVE_CRITICAL_SECTION(lock) do { \
-            spin_unlock_irqrestore((lock), g_flags); \
+            raw_spin_unlock_irqrestore((lock), g_flags); \
             g_flags = UINT32_MAX; \
         } while(0)
 

--- a/components/esp_hw_support/modem_clock.c
+++ b/components/esp_hw_support/modem_clock.c
@@ -26,10 +26,10 @@
 #ifdef __NuttX__
 #define ENTER_CRITICAL_SECTION(lock) do { \
             assert(g_flags == UINT32_MAX); \
-            g_flags = spin_lock_irqsave(lock); \
+            g_flags = raw_spin_lock_irqsave(lock); \
         } while(0)
 #define LEAVE_CRITICAL_SECTION(lock) do { \
-            spin_unlock_irqrestore((lock), g_flags); \
+            raw_spin_unlock_irqrestore((lock), g_flags); \
             g_flags = UINT32_MAX; \
         } while(0)
 #define LOCK_INITIALIZER_UNLOCKED       0

--- a/components/esp_hw_support/port/esp32/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32/sar_periph_ctrl.c
@@ -28,10 +28,10 @@
 #ifdef __NuttX__
 #define ENTER_CRITICAL_SECTION(lock) do { \
             assert(g_flags == UINT32_MAX); \
-            g_flags = spin_lock_irqsave(lock); \
+            g_flags = raw_spin_lock_irqsave(lock); \
         } while(0)
 #define LEAVE_CRITICAL_SECTION(lock) do { \
-            spin_unlock_irqrestore((lock), g_flags); \
+            raw_spin_unlock_irqrestore((lock), g_flags); \
             g_flags = UINT32_MAX; \
         } while(0)
 

--- a/components/esp_hw_support/port/esp32c3/adc2_init_cal.c
+++ b/components/esp_hw_support/port/esp32c3/adc2_init_cal.c
@@ -20,10 +20,10 @@ Don't put any other code into this file. */
 #ifdef __NuttX__
 #define ENTER_CRITICAL_SECTION(lock) do { \
             assert(g_flags == UINT32_MAX); \
-            g_flags = spin_lock_irqsave(lock); \
+            g_flags = raw_spin_lock_irqsave(lock); \
         } while(0)
 #define LEAVE_CRITICAL_SECTION(lock) do { \
-            spin_unlock_irqrestore((lock), g_flags); \
+            raw_spin_unlock_irqrestore((lock), g_flags); \
             g_flags = UINT32_MAX; \
         } while(0)
 

--- a/components/esp_hw_support/port/esp32c3/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32c3/sar_periph_ctrl.c
@@ -30,10 +30,10 @@
 #ifdef __NuttX__
 #define ENTER_CRITICAL_SECTION(lock) do { \
             assert(g_flags == UINT32_MAX); \
-            g_flags = spin_lock_irqsave(lock); \
+            g_flags = raw_spin_lock_irqsave(lock); \
         } while(0)
 #define LEAVE_CRITICAL_SECTION(lock) do { \
-            spin_unlock_irqrestore((lock), g_flags); \
+            raw_spin_unlock_irqrestore((lock), g_flags); \
             g_flags = UINT32_MAX; \
         } while(0)
 

--- a/components/esp_hw_support/port/esp32c6/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32c6/sar_periph_ctrl.c
@@ -29,10 +29,10 @@
 #ifdef __NuttX__
 #define ENTER_CRITICAL_SECTION(lock) do { \
             assert(g_flags == UINT32_MAX); \
-            g_flags = spin_lock_irqsave(lock); \
+            g_flags = raw_spin_lock_irqsave(lock); \
         } while(0)
 #define LEAVE_CRITICAL_SECTION(lock) do { \
-            spin_unlock_irqrestore((lock), g_flags); \
+            raw_spin_unlock_irqrestore((lock), g_flags); \
             g_flags = UINT32_MAX; \
         } while(0)
 

--- a/components/esp_hw_support/port/esp32h2/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32h2/sar_periph_ctrl.c
@@ -29,10 +29,10 @@
 #ifdef __NuttX__
 #define ENTER_CRITICAL_SECTION(lock) do { \
             assert(g_flags == UINT32_MAX); \
-            g_flags = spin_lock_irqsave(lock); \
+            g_flags = raw_spin_lock_irqsave(lock); \
         } while(0)
 #define LEAVE_CRITICAL_SECTION(lock) do { \
-            spin_unlock_irqrestore((lock), g_flags); \
+            raw_spin_unlock_irqrestore((lock), g_flags); \
             g_flags = UINT32_MAX; \
         } while(0)
 

--- a/components/esp_hw_support/regi2c_ctrl.c
+++ b/components/esp_hw_support/regi2c_ctrl.c
@@ -21,10 +21,10 @@
 #ifdef __NuttX__
 #define ENTER_CRITICAL_SECTION(lock) do { \
             assert(g_flags == UINT32_MAX); \
-            g_flags = spin_lock_irqsave(lock); \
+            g_flags = raw_spin_lock_irqsave(lock); \
         } while(0)
 #define LEAVE_CRITICAL_SECTION(lock) do { \
-            spin_unlock_irqrestore((lock), g_flags); \
+            raw_spin_unlock_irqrestore((lock), g_flags); \
             g_flags = UINT32_MAX; \
         } while(0)
 


### PR DESCRIPTION
esp32: replace spin_lock_irqsave with raw_spin_lock_irqsave.

Due to modifications in the NuttX API, in order to maintain the same semantics.

resolve the issue in nuttx https://github.com/apache/nuttx/issues/15688