### PR TITLE
components/wpa_supplicant: Prefix AES symbols on NuttX

### DIFF
--- a/components/wpa_supplicant/src/crypto/aes.h
+++ b/components/wpa_supplicant/src/crypto/aes.h
@@ -11,6 +11,12 @@
 
 #ifdef __NuttX__
 #include "utils/common.h"
+#define aes_encrypt_init esp_wpa_aes_encrypt_init
+#define aes_encrypt esp_wpa_aes_encrypt
+#define aes_encrypt_deinit esp_wpa_aes_encrypt_deinit
+#define aes_decrypt_init esp_wpa_aes_decrypt_init
+#define aes_decrypt esp_wpa_aes_decrypt
+#define aes_decrypt_deinit esp_wpa_aes_decrypt_deinit
 #endif
 
 #define AES_BLOCK_SIZE 16

--- a/components/wpa_supplicant/src/crypto/crypto.h
+++ b/components/wpa_supplicant/src/crypto/crypto.h
@@ -22,6 +22,15 @@
 #define CRYPTO_H
 #include "utils/common.h"
 
+#ifdef __NuttX__
+#define aes_encrypt_init esp_wpa_aes_encrypt_init
+#define aes_encrypt esp_wpa_aes_encrypt
+#define aes_encrypt_deinit esp_wpa_aes_encrypt_deinit
+#define aes_decrypt_init esp_wpa_aes_decrypt_init
+#define aes_decrypt esp_wpa_aes_decrypt
+#define aes_decrypt_deinit esp_wpa_aes_decrypt_deinit
+#endif
+
 /**
  * md4_vector - MD4 hash for data vector
  * @num_elem: Number of elements in the data vector


### PR DESCRIPTION
## Summary

Prefix the wpa_supplicant AES block helper symbols when building for NuttX.

## Motivation

NuttX builds selected components into a shared flat symbol namespace. When the software cryptodev backend enables `crypto/aes.c`, its `aes_encrypt()` and `aes_decrypt()` symbols collide with the wpa_supplicant mbedTLS crypto wrapper.

Using `esp_wpa_`-prefixed symbols keeps the ESP Wi-Fi stack compatible with NuttX's software crypto implementation while preserving the existing API names for non-NuttX builds.

## Testing

Built NuttX ESP32-C3 configuration using Wi-Fi plus software cryptodev/AES after referencing this branch from NuttX.